### PR TITLE
Use raw string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ gura = "0.2.0"
 use gura::{dump, parse, GuraType};
 
 fn main() {
-    let gura_string = "
+    let gura_string = r##"
 # This is a Gura document.
-title: \"Gura Example\"
+title: "Gura Example"
 
 an_object:
-    username: \"Stephen\"
-    pass: \"Hawking\"
+    username: "Stephen"
+    pass: "Hawking"
 
 # Line breaks are OK when inside arrays
 hosts: [
-  \"alpha\",
-  \"omega\"
-]"
+  "alpha",
+  "omega"
+]"##
     .to_string();
 
     // Parse: transforms a Gura string into a dictionary

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,19 +2,19 @@
 use gura::{dump, parse, GuraType};
 
 fn main() {
-    let gura_string = "
+    let gura_string = r##"
 # This is a Gura document.
-title: \"Gura Example\"
+title: "Gura Example"
 
 an_object:
-    username: \"Stephen\"
-    pass: \"Hawking\"
+    username: "Stephen"
+    pass: "Hawking"
 
 # Line breaks are OK when inside arrays
 hosts: [
-  \"alpha\",
-  \"omega\"
-]"
+  "alpha",
+  "omega"
+]"##
     .to_string();
 
     // Parse: transforms a Gura string into a dictionary


### PR DESCRIPTION
So there is no need the escape the double quotes inside that string.

Quoting https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
  Raw string literals do not process any escapes. They start with the
  character U+0072 (r), followed by zero or more of the character U+0023
  (#) and a U+0022 (double-quote) character. The raw string body can
  contain any sequence of Unicode characters and is terminated only by
  another U+0022 (double-quote) character, followed by the same number of
  U+0023 (#) characters that preceded the opening U+0022 (double-quote)
  character.