### PR TITLE
Move generater functions to statics with lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ unicode-segmentation = "1.7.1"
 regex = "1.5.4"
 indexmap = "1.7.0"
 float-pretty-print = "0.1.0"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
qoute from [lazy_static docs](https://docs.rs/lazy_static/1.4.0/lazy_static/)

> Using this macro, it is possible to have statics that require code to be executed at runtime in order to be initialized. This includes anything requiring heap allocations, like vectors or hash maps, as well as anything that requires function calls to be computed.

Which is exactly whats happening here.
Also cleaned up use statements.