### PR TITLE
Remove check than get to match on get

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::{HashMap, HashSet},
     env,
@@ -523,10 +524,9 @@ fn basic_string(text: &mut Input) -> RuleResult {
                     };
                 } else {
                     // Gets escaped char or interprets as literal
-                    let escaped_char: String = if CHARS_TO_ESCAPE.contains_key(escape.as_str()) {
-                        CHARS_TO_ESCAPE.get(escape.as_str()).unwrap().to_string()
-                    } else {
-                        current_char + &escape
+                    let escaped_char = match CHARS_TO_ESCAPE.get(escape.as_str()) {
+                        Some(v) => Cow::Borrowed(*v),
+                        None => Cow::Owned(current_char + &escape),
                     };
 
                     final_string.push_str(&escaped_char);


### PR DESCRIPTION
We can use a [`Cow`](https://doc.rust-lang.org/stable/std/borrow/enum.Cow.html) to not allocate to a string when we have this case. 

I know this pattern is common in other languages to check for something and then get it. However in rust if we are interested in the value we can just get it and match the returned `Option`. It removes double indexing in the map for the case. 