### PR TITLE
Fix panic when import paths exist but are not readable

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -619,19 +619,18 @@ fn compute_imports(text: &mut Input, parent_dir_path: Option<String>) -> Result<
                 });
             }
 
-            // Checks if file exists
-            let file_exists = fs::metadata(&file_to_import).is_ok();
-            if !file_exists {
-                return Err(GuraError {
-                    pos: 0,
-                    line: 0,
-                    msg: format!("The file \"{}\" does not exist", file_to_import),
-                    kind: Error::FileNotFoundError,
-                });
-            }
-
             // Gets content considering imports
-            let content = fs::read_to_string(&file_to_import).unwrap();
+            let content = match fs::read_to_string(&file_to_import) {
+                Ok(content) => content,
+                Err(_) => {
+                    return Err(GuraError {
+                        pos: 0,
+                        line: 0,
+                        msg: format!("The file \"{}\" does not exist", file_to_import),
+                        kind: Error::FileNotFoundError,
+                    });
+                }
+            };
             let parent_dir_path = Path::new(&file_to_import).parent().unwrap();
             let mut empty_input = Input::new();
             let content_with_import = get_text_with_imports(
@@ -1694,8 +1693,7 @@ fn dump_content(content: &GuraType) -> String {
             });
 
             if !should_multiline {
-                let stringify_values: Vec<String> =
-                    array.iter().map(dump_content).collect();
+                let stringify_values: Vec<String> = array.iter().map(dump_content).collect();
                 let joined = stringify_values.iter().cloned().join(", ");
                 return format!("[{}]", joined);
             }


### PR DESCRIPTION
- Also fixes a potential race condition when the file is deleted after the exists check passes.

Tested with `examples/noaccess.rs`:

```rust
// Basic Gura parser usage example
use gura::parse;

fn main() -> Result<(), String> {
    let gura_string = r##"
import "examples/noaccess.ura"
]"##;

    // Parse: transforms a Gura string into a dictionary
    let parsed = parse(gura_string).map_err(|e| e.to_string())?;

    println!("Parsed:\n{:?}", parsed);

    Ok(())
}
```

Create an unreadable file and try it:

```bash
$ touch examples/noaccess.ura
$ chmod -r examples/noaccess.ura
$ cargo run --example noaccess
   Compiling gura v0.5.0 (/Users/parasyte/other-projects/gura-rs-parser)
    Finished dev [unoptimized + debuginfo] target(s) in 1.62s
     Running `target/debug/examples/noaccess`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }', src/parser.rs:634:63
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```