### PR TITLE
Fix clippy lint

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,7 +17,7 @@ hosts: [
 ]"##;
 
     // Parse: transforms a Gura string into a dictionary
-    let parsed = parse(&gura_string).unwrap();
+    let parsed = parse(gura_string).unwrap();
 
     // Debug and Display
     // println!("{:#?}", parsed);

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -35,7 +35,7 @@ fn main() {
     ]
 ]"##;
 
-    let parsed = parse(&str).unwrap();
+    let parsed = parse(str).unwrap();
     let dumped = dump(&parsed);
     assert_eq!(str.trim(), dumped.trim());
 }

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -9,7 +9,7 @@ some_invalid: $non_existent_var
 "##;
 
     // Checks parsing result
-    match parse(&gura_string) {
+    match parse(gura_string) {
         Ok(parsed) => {
             println!("Title -> {}", parsed["title"]);
         }

--- a/examples/with_structs.rs
+++ b/examples/with_structs.rs
@@ -27,7 +27,7 @@ tango_singers: [
 ]"##;
 
     // Parse: transforms a Gura string into a dictionary
-    let parsed = parse(&gura_string).unwrap();
+    let parsed = parse(gura_string).unwrap();
 
 	// Lets make an array of singers
     if let GuraType::Array(tango_singers) = &parsed["tango_singers"] {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// All Gura error variants
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Raises when Gura syntax is invalid
     ParseError,
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 /// A Gura error with position, line and custom message
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GuraError {
     pub pos: isize,
     pub line: usize,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,8 @@ use std::{
     collections::{HashMap, HashSet},
     env,
     f64::{INFINITY, NAN, NEG_INFINITY},
-    fmt, fs,
+    fmt::{self, Write as _},
+    fs,
     ops::Index,
     path::Path,
     usize,
@@ -782,7 +783,7 @@ fn char(text: &mut Input, chars: &Option<String>) -> Result<String, GuraError> {
                 }
             }
 
-            return Err(GuraError {
+            Err(GuraError {
                 pos: next_char_pos,
                 line: text.line,
                 msg: format!(
@@ -790,7 +791,7 @@ fn char(text: &mut Input, chars: &Option<String>) -> Result<String, GuraError> {
                     chars_value, text.text[next_char_pos_usize]
                 ),
                 kind: Error::ParseError,
-            });
+            })
         }
     }
 }
@@ -1657,25 +1658,25 @@ fn dump_content(content: &GuraType) -> String {
 
             let mut result = String::new();
             for (key, gura_value) in values.iter() {
-                result.push_str(&format!("{}:", key));
+                let _ = write!(result, "{}:", key);
 
                 // If the value is an object, splits the stringified value by
                 // newline and indents each line before adding it to the result
-                if let GuraType::Object(obj) = &*gura_value {
+                if let GuraType::Object(obj) = gura_value {
                     let dumped = dump_content(gura_value);
                     let stringified_value = dumped.trim_end();
                     if !obj.is_empty() {
                         result.push('\n');
 
                         for line in stringified_value.split('\n') {
-                            result.push_str(&format!("{}{}\n", INDENT, line));
+                            let _ = writeln!(result, "{}{}", INDENT, line);
                         }
                     } else {
                         // Prevents indentation on empty objects
-                        result.push_str(&format!(" {}\n", stringified_value));
+                        let _ = writeln!(result, " {}", stringified_value);
                     }
                 } else {
-                    result.push_str(&format!(" {}\n", dump_content(gura_value)));
+                    let _ = writeln!(result, " {}", dump_content(gura_value));
                 }
             }
 
@@ -1685,7 +1686,7 @@ fn dump_content(content: &GuraType) -> String {
             // Lists are a special case: if it has an object, and indented representation must be returned. In case
             // of primitive values or nested arrays, a plain representation is more appropriated
             let should_multiline = array.iter().any(|e| {
-                if let GuraType::Object(obj) = &*e {
+                if let GuraType::Object(obj) = e {
                     !obj.is_empty()
                 } else {
                     false
@@ -1717,7 +1718,7 @@ fn dump_content(content: &GuraType) -> String {
                     result += &splitted.iter().cloned().join("\n");
                 } else {
                     // Otherwise indent the value and add to result
-                    result.push_str(&format!("{}{}", INDENT, stringified_value));
+                    let _ = write!(result, "{}{}", INDENT, stringified_value);
                 }
 
                 // Add a comma if this entry is not the final entry in the list

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -149,7 +149,7 @@ fn test_dumps_result() {
     ]
 ]"##;
 
-    let parsed = parse(&str).unwrap();
+    let parsed = parse(str).unwrap();
     let dumped = dump(&parsed);
     assert_eq!(str, dumped);
 }
@@ -168,34 +168,34 @@ fn test_dumps_nan() {
 #[test]
 /// Tests empty Gura documents
 fn test_empty() {
-    let parsed_data = parse(&"").unwrap();
+    let parsed_data = parse("").unwrap();
     assert_eq!(parsed_data, object! {});
 }
 
 #[test]
 /// Tests empty Gura documents, even when some data is defined
 fn test_empty_2() {
-    let parsed_data = parse(&"$unused_var: 5").unwrap();
+    let parsed_data = parse("$unused_var: 5").unwrap();
     assert_eq!(parsed_data, object! {});
 }
 
 #[test]
 /// Tests invalid key
 fn test_invalid_key() {
-    let parsed_data = parse(&"with.dot: 5");
+    let parsed_data = parse("with.dot: 5");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests invalid key
 fn test_invalid_key_2() {
-    let parsed_data = parse(&"\"with_quotes\": 5");
+    let parsed_data = parse("\"with_quotes\": 5");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests invalid key
 fn test_invalid_key_3() {
-    let parsed_data = parse(&"with-dashes: 5");
+    let parsed_data = parse("with-dashes: 5");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }

--- a/tests/importing.rs
+++ b/tests/importing.rs
@@ -40,7 +40,7 @@ fn test_with_variables() {
 #[test]
 /// Tests errors importing a non existing file
 fn test_not_found_error() {
-    let parsed_data = parse(&"import \"invalid_file.ura\"");
+    let parsed_data = parse("import \"invalid_file.ura\"");
     assert_eq!(parsed_data.unwrap_err().kind, Error::FileNotFoundError);
 }
 
@@ -92,13 +92,13 @@ fn test_with_absolute_paths() {
 #[test]
 /// Tests errors invalid importing sentence (there are blanks before import)
 fn test_parse_error_1() {
-    let parsed_data = parse(&"  import \"another_file.ura\"");
+    let parsed_data = parse("  import \"another_file.ura\"");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests errors invalid importing sentence (there are more than one whitespace between import and file name)
 fn test_parse_error_2() {
-    let parsed_data = parse(&"import   \"another_file.ura\"");
+    let parsed_data = parse("import   \"another_file.ura\"");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }

--- a/tests/objects.rs
+++ b/tests/objects.rs
@@ -38,14 +38,14 @@ fn test_normal() {
 #[test]
 /// Tests empty object
 fn test_empty() {
-    let parsed_data = parse(&"empty_object: empty").unwrap();
+    let parsed_data = parse("empty_object: empty").unwrap();
     assert_eq!(parsed_data, get_empty_object());
 }
 
 #[test]
 /// Tests empty object with several blanks
 fn test_empty_2() {
-    let parsed_data = parse(&"empty_object:     empty    ").unwrap();
+    let parsed_data = parse("empty_object:     empty    ").unwrap();
     assert_eq!(parsed_data, get_empty_object());
 }
 

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -82,7 +82,7 @@ fn test_multiline_basic_strings() {
 #[test]
 /// Tests errors in basic strings
 fn test_basic_strings_errors() {
-    let parsed_data = parse(&"test: \"$false_var\"");
+    let parsed_data = parse("test: \"$false_var\"");
     assert_eq!(
         parsed_data.unwrap_err().kind,
         Error::VariableNotDefinedError

--- a/tests/variables.rs
+++ b/tests/variables.rs
@@ -31,7 +31,7 @@ fn test_normal() {
 #[test]
 /// Tests errors in variables definition
 fn test_with_error() {
-    let parsed_data = parse(&"test: $false_var");
+    let parsed_data = parse("test: $false_var");
     assert_eq!(
         parsed_data.unwrap_err().kind,
         Error::VariableNotDefinedError
@@ -41,7 +41,7 @@ fn test_with_error() {
 #[test]
 /// Tests errors in variables definition
 fn test_with_duplicated() {
-    let parsed_data = parse(&"$a_var: 14\n$a_var: 15");
+    let parsed_data = parse("$a_var: 14\n$a_var: 15");
     assert_eq!(
         parsed_data.unwrap_err().kind,
         Error::DuplicatedVariableError
@@ -63,28 +63,28 @@ fn test_env_var() {
 #[test]
 /// Tests invalid variable value type
 fn test_invalid_variable() {
-    let parsed_data = parse(&"$invalid: true");
+    let parsed_data = parse("$invalid: true");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests invalid variable value type
 fn test_invalid_variable_2() {
-    let parsed_data = parse(&"$invalid: false");
+    let parsed_data = parse("$invalid: false");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests invalid variable value type
 fn test_invalid_variable_3() {
-    let parsed_data = parse(&"$invalid: null");
+    let parsed_data = parse("$invalid: null");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 
 #[test]
 /// Tests invalid variable value type
 fn test_invalid_variable_4() {
-    let parsed_data = parse(&"$invalid: [ 1, 2, 3]");
+    let parsed_data = parse("$invalid: [ 1, 2, 3]");
     assert_eq!(parsed_data.unwrap_err().kind, Error::ParseError);
 }
 


### PR DESCRIPTION
- This is mostly the result of `cargo clippy --all --fix`
- The exceptions are the transformations from `s.push_str(&format!(...))` -> `write!(s, ...)`, which clippy would not automate.